### PR TITLE
Add recipe customization pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,24 +272,21 @@
   <h1>今天中午吃什么?</h1>
   
   <div class="buttons">
-    
-    
     <!-- 食材甄选按钮 -->
-    <button class="ingredients-btn" style="background-image: url('./images/ingredients.jpeg')">
-    
+    <button class="ingredients-btn button" style="background-image: url('./images/ingredients.jpeg')">
+      <div class="button-tooltip">食材甄选</div>
+    </button>
+
     <!-- 菜品推荐按钮 -->
-      <a href="recommendation.html" class="dishes-btn">
-        <button class="dishes-btn" style="background-image: url('./images/dishes.jpeg')">
-          <div class="button-tooltip">菜品推荐</div>
-        </button>
-      </a>
+    <button class="dishes-btn button" style="background-image: url('./images/dishes.jpeg')">
       <div class="button-tooltip">菜品推荐</div>
-    
-    
+    </button>
+
     <!-- 食谱定制按钮 -->
-    <button class="recipes-btn" style="background-image: url('./images/recipes.jpeg')">
+    <button class="recipes-btn button" style="background-image: url('./images/recipes.jpeg')">
       <div class="button-tooltip">食谱定制</div>
-    </div>
+    </button>
+  </div>
 
   
   <script>
@@ -314,12 +311,13 @@
     
     // 点击按钮的功能（可以进一步扩展）
     document.querySelectorAll('.button').forEach((button, index) => {
+      const links = ["#", "recommendation.html", "recipe_photo.html"];
       button.addEventListener('click', function() {
-        const actions = ["食材甄选", "菜品推荐", "食谱定制"];
-        alert(`进入功能：${actions[index]}`);
-        
-        // 实际应用中可以跳转到对应页面
-        // window.location.href = `/${actions[index]}.html`;
+        if(links[index] === "#") {
+          alert('进入功能：食材甄选');
+        } else {
+          window.location.href = links[index];
+        }
       });
     });
   </script>

--- a/recipe_dishes.html
+++ b/recipe_dishes.html
@@ -7,7 +7,7 @@
 <style>
   body { margin:0; font-family:Arial, "Microsoft YaHei", sans-serif; background:#f7efd2 url('./images/background.jpeg') center/cover fixed; min-height:100vh; display:flex; flex-direction:column; align-items:center; padding-top:30px; }
   h1{ font-size:2rem; font-weight:bold; margin-bottom:20px; }
-  .cards{ display:flex; overflow-x:auto; gap:10px; padding:10px; width:90%; }
+  .cards{ display:flex; flex-wrap:wrap; justify-content:center; gap:20px; padding:10px; width:90%; max-width:900px; }
   .card{ flex:0 0 220px; background:rgba(255,255,255,0.8); border-radius:10px; text-align:center; padding:10px; }
   .card img{ width:100%; border-radius:10px; }
   .select{ margin-top:6px; }

--- a/recipe_dishes.html
+++ b/recipe_dishes.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>食谱定制 - 菜品生成</title>
+<style>
+  body { margin:0; font-family:Arial, "Microsoft YaHei", sans-serif; background:#f7efd2 url('./images/background.jpeg') center/cover fixed; min-height:100vh; display:flex; flex-direction:column; align-items:center; padding-top:30px; }
+  h1{ font-size:2rem; font-weight:bold; margin-bottom:20px; }
+  .cards{ display:flex; overflow-x:auto; gap:10px; padding:10px; width:90%; }
+  .card{ flex:0 0 220px; background:rgba(255,255,255,0.8); border-radius:10px; text-align:center; padding:10px; }
+  .card img{ width:100%; border-radius:10px; }
+  .select{ margin-top:6px; }
+  .nav{ margin-top:20px; }
+</style>
+</head>
+<body>
+  <h1>食谱定制</h1>
+  <div class="cards">
+    <div class="card">
+      <img src="./images/dishes.jpeg" alt="小炒黄牛肉">
+      <h3>小炒黄牛肉</h3>
+      <p>牛肉八十克 青椒五十克</p>
+      <div class="select"><input type="radio" name="dish" value="1"></div>
+    </div>
+    <div class="card">
+      <img src="./images/dishes.jpeg" alt="凉拌黄瓜">
+      <h3>凉拌黄瓜</h3>
+      <p>黄瓜二百克</p>
+      <div class="select"><input type="radio" name="dish" value="2"></div>
+    </div>
+    <div class="card">
+      <img src="./images/dishes.jpeg" alt="鸡蛋炒玉米">
+      <h3>鸡蛋炒玉米</h3>
+      <p>玉米一百克 鸡蛋一百克</p>
+      <div class="select"><input type="radio" name="dish" value="3"></div>
+    </div>
+    <div class="card">
+      <img src="./images/dishes.jpeg" alt="黄瓜炒鸡蛋">
+      <h3>黄瓜炒鸡蛋</h3>
+      <p>黄瓜一百克 鸡蛋一百克</p>
+      <div class="select"><input type="radio" name="dish" value="4"></div>
+    </div>
+  </div>
+  <button class="nav" onclick="location.href='recipe_guide.html'">下一步</button>
+</body>
+</html>

--- a/recipe_guide.html
+++ b/recipe_guide.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>食谱定制 - 菜谱指导</title>
+<style>
+  body{margin:0;font-family:Arial,"Microsoft YaHei",sans-serif;background:#f7efd2 url('./images/background.jpeg') center/cover fixed;min-height:100vh;display:flex;flex-direction:column;align-items:center;padding-top:30px;}
+  h1{font-size:2rem;font-weight:bold;margin-bottom:10px;}
+  #steps{position:relative;width:90%;max-width:600px;overflow:hidden;}
+  .step{width:100%;display:none;text-align:center;background:rgba(255,255,255,0.8);border-radius:10px;padding:20px;}
+  .step.active{display:block;}
+  .nav-btn{margin-top:20px;}
+  .dots{margin-top:10px;text-align:center;}
+  .dot{display:inline-block;width:10px;height:10px;border-radius:50%;background:#ccc;margin:0 4px;}
+  .dot.active{background:#4caf50;}
+  .ingredients{ text-align:left; margin-bottom:10px; }
+</style>
+</head>
+<body>
+<h1>食谱定制</h1>
+<div id="steps">
+  <div class="step active" id="s1">
+    <h2>Step 1 食材准备</h2>
+    <div class="ingredients">
+      <strong>主料:</strong> 甜玉米粒二百克 鸡蛋三个<br>
+      <strong>配菜:</strong> 香葱一根 胡萝卜三十克<br>
+      <strong>调味料:</strong> 盐半茶匙 糖一小勺 水淀粉一份<br>
+      <strong>技巧:</strong> 玉米粒焯水方便去腥
+    </div>
+    <img src="./images/ingredients.jpeg" style="width:100%;border-radius:10px;" alt="准备">
+  </div>
+  <div class="step" id="s2">
+    <h2>Step 2 烹饪步骤</h2>
+    <img src="./images/dishes.jpeg" style="width:100%;border-radius:10px;" alt="烹饪">
+  </div>
+  <div class="step" id="s3">
+    <h2>Step 3 升级技巧</h2>
+    <img src="./images/recipes.jpeg" style="width:100%;border-radius:10px;" alt="完成">
+  </div>
+</div>
+<div class="dots">
+  <span class="dot active"></span>
+  <span class="dot"></span>
+  <span class="dot"></span>
+</div>
+<button class="nav-btn" onclick="prevStep()">上一页</button>
+<button class="nav-btn" onclick="nextStep()">下一页</button>
+<script>
+var current=0;
+var steps=document.querySelectorAll('.step');
+var dots=document.querySelectorAll('.dot');
+function show(idx){
+  steps.forEach((s,i)=>{s.classList.toggle('active',i===idx)});
+  dots.forEach((d,i)=>{d.classList.toggle('active',i===idx)});
+  current=idx;
+}
+function prevStep(){ if(current>0) show(current-1); }
+function nextStep(){ if(current<steps.length-1) show(current+1); }
+</script>
+</body>
+</html>

--- a/recipe_guide.html
+++ b/recipe_guide.html
@@ -10,7 +10,8 @@
   #steps{position:relative;width:90%;max-width:600px;overflow:hidden;}
   .step{width:100%;display:none;text-align:center;background:rgba(255,255,255,0.8);border-radius:10px;padding:20px;}
   .step.active{display:block;}
-  .nav-btn{margin-top:20px;}
+  .nav-btns{display:flex; gap:20px; justify-content:center; margin-top:20px;}
+  .nav-btn{padding:8px 16px;border:none;border-radius:6px;background:white;color:#7b4f21;cursor:pointer;}
   .dots{margin-top:10px;text-align:center;}
   .dot{display:inline-block;width:10px;height:10px;border-radius:50%;background:#ccc;margin:0 4px;}
   .dot.active{background:#4caf50;}
@@ -44,8 +45,10 @@
   <span class="dot"></span>
   <span class="dot"></span>
 </div>
-<button class="nav-btn" onclick="prevStep()">上一页</button>
-<button class="nav-btn" onclick="nextStep()">下一页</button>
+<div class="nav-btns">
+  <button class="nav-btn" onclick="prevStep()">上一页</button>
+  <button class="nav-btn" onclick="nextStep()">下一页</button>
+</div>
 <script>
 var current=0;
 var steps=document.querySelectorAll('.step');

--- a/recipe_photo.html
+++ b/recipe_photo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>食谱定制 - 拍照识别</title>
+<style>
+  body {
+    margin: 0;
+    font-family: Arial, "Microsoft YaHei", sans-serif;
+    background: #f7efd2 url('./images/background.jpeg') center/cover fixed;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-top: 40px;
+  }
+  h1 {
+    font-size: 2.2rem;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 20px;
+  }
+  .camera-area {
+    width: 80vw;
+    max-width: 320px;
+    background: white;
+    border-radius: 20px;
+    aspect-ratio: 1 / 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  }
+  .capture-btn {
+    margin-top: 20px;
+    padding: 10px 20px;
+    border-radius: 8px;
+    border: none;
+    background: white;
+    color: #7b4f21;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+</style>
+</head>
+<body>
+  <h1>食谱定制</h1>
+  <div class="camera-area">
+    <!-- 拍照画面占位 -->
+  </div>
+  <button class="capture-btn" onclick="location.href='recipe_result.html'">📷 点击拍照</button>
+</body>
+</html>

--- a/recipe_result.html
+++ b/recipe_result.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>食谱定制 - 识别结果</title>
+<style>
+  body {
+    margin: 0;
+    font-family: Arial, "Microsoft YaHei", sans-serif;
+    background: #f7efd2 url('./images/background.jpeg') center/cover fixed;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 30px;
+  }
+  h1 { font-size: 2rem; font-weight: bold; margin-bottom:20px; }
+  .container { display:flex; flex-wrap:wrap; width:90%; max-width:900px; }
+  .photo { flex:1; min-width:240px; text-align:center; }
+  .photo img { width:90%; max-width:300px; border-radius:10px; }
+  .photo button { margin-top:10px; padding:6px 14px; border:none; border-radius:6px; background:#fff; cursor:pointer; }
+  .info { flex:1; min-width:240px; padding:0 10px; }
+  .info section { background:rgba(255,255,255,0.8); padding:10px; border-radius:10px; margin-bottom:10px; }
+  .info ul { list-style:none; padding:0; }
+  .info li { margin-bottom:6px; }
+  .add-btn { margin-top:6px; padding:4px 10px; border:none; background:#fff; border-radius:6px; cursor:pointer; }
+</style>
+</head>
+<body>
+  <h1>食谱定制</h1>
+  <div class="container">
+    <div class="photo">
+      <img src="./images/recipes.jpeg" alt="food">
+      <button onclick="location.href='recipe_photo.html'">重试一次</button>
+    </div>
+    <div class="info">
+      <section>
+        <h3>已有食物</h3>
+        <ul>
+          <li>黄瓜 1根 200g <button>编辑</button> <button>删除</button></li>
+          <li>鸡蛋 2个 100g <button>编辑</button> <button>删除</button></li>
+        </ul>
+        <button class="add-btn">添加更多</button>
+      </section>
+      <section>
+        <h3>营养成分</h3>
+        <ul>
+          <li>能量 200kcal <button>编辑</button> <button>删除</button></li>
+          <li>蛋白质 10g <button>编辑</button> <button>删除</button></li>
+          <li>脂肪 5g <button>编辑</button> <button>删除</button></li>
+          <li>碳水化合物 20g <button>编辑</button> <button>删除</button></li>
+        </ul>
+        <button class="add-btn">添加更多</button>
+      </section>
+    </div>
+  </div>
+  <button class="capture-btn" style="margin-top:20px;" onclick="location.href='recipe_dishes.html'">生成菜品</button>
+</body>
+</html>

--- a/recipe_result.html
+++ b/recipe_result.html
@@ -16,15 +16,19 @@
     padding-top: 30px;
   }
   h1 { font-size: 2rem; font-weight: bold; margin-bottom:20px; }
-  .container { display:flex; flex-wrap:wrap; width:90%; max-width:900px; }
+  .container { display:flex; flex-wrap:wrap; justify-content:center; gap:20px; width:90%; max-width:900px; }
   .photo { flex:1; min-width:240px; text-align:center; }
   .photo img { width:90%; max-width:300px; border-radius:10px; }
-  .photo button { margin-top:10px; padding:6px 14px; border:none; border-radius:6px; background:#fff; cursor:pointer; }
-  .info { flex:1; min-width:240px; padding:0 10px; }
+  .info { flex:1; min-width:260px; padding:0 10px; }
   .info section { background:rgba(255,255,255,0.8); padding:10px; border-radius:10px; margin-bottom:10px; }
-  .info ul { list-style:none; padding:0; }
-  .info li { margin-bottom:6px; }
+  .info ul { list-style:none; padding:0; margin:0; }
+  .info li { display:flex; justify-content:space-between; align-items:center; margin-bottom:6px; }
+  .btns button{ margin-left:4px; }
+  .edit-btn{ background:#8bc34a; color:#fff; border:none; border-radius:4px; padding:2px 8px; font-size:0.8rem; cursor:pointer; }
+  .del-btn{ background:#f44336; color:#fff; border:none; border-radius:4px; padding:2px 8px; font-size:0.8rem; cursor:pointer; }
   .add-btn { margin-top:6px; padding:4px 10px; border:none; background:#fff; border-radius:6px; cursor:pointer; }
+  .actions{ margin-top:20px; display:flex; gap:20px; width:90%; max-width:500px; justify-content:center; }
+  .actions button{ flex:1; padding:10px 20px; border-radius:8px; border:none; background:white; color:#7b4f21; font-size:1rem; cursor:pointer; }
 </style>
 </head>
 <body>
@@ -32,29 +36,31 @@
   <div class="container">
     <div class="photo">
       <img src="./images/recipes.jpeg" alt="food">
-      <button onclick="location.href='recipe_photo.html'">重试一次</button>
     </div>
     <div class="info">
       <section>
         <h3>已有食物</h3>
         <ul>
-          <li>黄瓜 1根 200g <button>编辑</button> <button>删除</button></li>
-          <li>鸡蛋 2个 100g <button>编辑</button> <button>删除</button></li>
+          <li><span>黄瓜 1根 200g</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
+          <li><span>鸡蛋 2个 100g</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
         </ul>
         <button class="add-btn">添加更多</button>
       </section>
       <section>
         <h3>营养成分</h3>
         <ul>
-          <li>能量 200kcal <button>编辑</button> <button>删除</button></li>
-          <li>蛋白质 10g <button>编辑</button> <button>删除</button></li>
-          <li>脂肪 5g <button>编辑</button> <button>删除</button></li>
-          <li>碳水化合物 20g <button>编辑</button> <button>删除</button></li>
+          <li><span>能量 200kcal</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
+          <li><span>蛋白质 10g</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
+          <li><span>脂肪 5g</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
+          <li><span>碳水化合物 20g</span><span class="btns"><button class="edit-btn">编辑</button><button class="del-btn">删除</button></span></li>
         </ul>
         <button class="add-btn">添加更多</button>
       </section>
     </div>
   </div>
-  <button class="capture-btn" style="margin-top:20px;" onclick="location.href='recipe_dishes.html'">生成菜品</button>
+  <div class="actions">
+    <button onclick="location.href='recipe_photo.html'">重试一次</button>
+    <button onclick="location.href='recipe_dishes.html'">生成菜品</button>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wire the `食谱定制` button on the home page
- add new pages for photo capture, recognition result, dish selection and cooking guide

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685570457378833392b124f917122e0e